### PR TITLE
Fix Lawnchair denials

### DIFF
--- a/common/private/priv_app.te
+++ b/common/private/priv_app.te
@@ -1,1 +1,3 @@
 allow priv_app ota_package_file:dir create_dir_perms;
+allow priv_app theme_prop:file read;
+allow priv_app theme_prop:file open;


### PR DESCRIPTION
These rules will fix the following denials:

type=1400 audit(0.0:44): avc: denied { read } for name="u:object_r:theme_prop:s0" 
dev="tmpfs" ino=22249 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:theme_prop:s0 tclass=file permissive=0

type=1400 audit(0.0:195): avc: denied { open } for path="/dev/__properties__/u:object_r:theme_prop:s0" dev="tmpfs" ino=22211 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:theme_prop:s0 tclass=file permissive=0 app=ch.deletescape.lawnchair.ci