### PR TITLE
sepolicy: let matlog read dmesg

### DIFF
--- a/common/private/priv_app.te
+++ b/common/private/priv_app.te
@@ -1,5 +1,6 @@
 allow priv_app ota_package_file:dir create_dir_perms;
 allow priv_app theme_prop:file { read open };
+allow priv_app kernel:system { syslog_read };
 
 # Allow Settings to read theme_prop
 get_prop(priv_app, theme_prop)


### PR DESCRIPTION
Matlog creates empty dmesg.txt and this denial shows up in dmesg.

[72.720424]  [33mtype=1400 audit(1597315422.502:503) [0m: avc: denied { syslog_read } for comm="dmesg" scontext=u:r:priv_app:s0:c512,c768 tcontext=u:r:kernel:s0 tclass=system permissive=0

After addressing it, matlog can create dmesg.txt correctly.

Signed-off-by: DarkDampSquib <andrin.geiger1998@gmail.com>